### PR TITLE
Add phpmyadmin service

### DIFF
--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,6 +47,17 @@ services:
       - db:/var/lib/mysql
     networks:
       - database
+  phpmyadmin:
+    image: phpmyadmin:latest
+    environment:
+      PMA_HOST: database
+    networks:
+      - database
+      - internet
+    ports:
+      - "5081:80"
+    profiles:
+      - dev
 volumes:
   db: {}
 


### PR DESCRIPTION
It is very useful to have some graphical way to explore the databases, for example during migration. This PR adds a `phpmyadmin` service which is only started when the compose profile `dev` is specified.