### PR TITLE
Use docker secrets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,7 @@ _vimrc_local.vim
 /docker/deployment.env
 /docker/dev/.env
 /docker/dev/deployment.env
+/docker/secrets/
 
 # Project files
 /config/config.php

--- a/config/config.default.php
+++ b/config/config.default.php
@@ -10,7 +10,7 @@ return [
         'host'     => env('MYSQL_HOST', (env('CI', false) ? 'mariadb' : 'localhost')),
         'database' => env('MYSQL_DATABASE', 'engelsystem'),
         'username' => env('MYSQL_USER', 'root'),
-        'password' => env('MYSQL_PASSWORD', ''),
+        'password' => env('MYSQL_PASSWORD', (env('MYSQL_PASSWORD_FILE', '') ? file_get_contents(env('MYSQL_PASSWORD_FILE')) : '')),
     ],
 
     // For accessing /metrics (and /stats)

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -9,7 +9,7 @@ services:
     environment:
       MYSQL_HOST: helferinnen_database
       MYSQL_USER: helferinnensystem
-      MYSQL_PASSWORD: helferinnensystem
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
       MYSQL_DATABASE: helferinnensystem
       APP_NAME: Helferinnensystem
       CONTACT_EMAIL: "mailto:helfen@froscon.org"
@@ -35,18 +35,23 @@ services:
       - internet
     depends_on:
       - helferinnen_database
+    secrets:
+      - db_password
   helferinnen_database:
     image: mariadb:10.2
     environment:
       MYSQL_DATABASE: helferinnensystem
       MYSQL_USER: helferinnensystem
-      MYSQL_PASSWORD: helferinnensystem
-      MYSQL_RANDOM_ROOT_PASSWORD: 1
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
       MYSQL_INITDB_SKIP_TZINFO: "yes"
     volumes:
       - db:/var/lib/mysql
     networks:
       - database
+    secrets:
+      - db_root_password
+      - db_password
 volumes:
   db: {}
 
@@ -54,3 +59,9 @@ networks:
   database:
     internal: true
   internet:
+
+secrets:
+  db_password:
+    file: secrets/mysql_pw.txt
+  db_root_password:
+    file: secrets/mysql_root_pw.txt

--- a/docker/secrets/mysql_pw.txt
+++ b/docker/secrets/mysql_pw.txt
@@ -1,0 +1,1 @@
+helferinnensystem

--- a/docker/secrets/mysql_root_pw.txt
+++ b/docker/secrets/mysql_root_pw.txt
@@ -1,0 +1,1 @@
+helferinnensystem


### PR DESCRIPTION
The proper way to use passwords in a docker setup are secrets. This also plays very nicely with out git setup: the passwords live in their own (.gitignored) files that are changed locally without tainting the local working copy.
