### PR TITLE
Add backup service

### DIFF
--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,8 +4,8 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   1   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
-0   2   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
+0   *   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
+42  3   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine
+
+RUN apk update && \
+    apk add mariadb-client && \
+    echo -e "\
+# m	h	d	m	wd	command\n\
+0   1   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
+0   2   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
+" > /root/crontab && \
+    crontab /root/crontab && \
+    mkdir /backup
+
+ENTRYPOINT /usr/sbin/crond -f -l 2

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,8 +47,25 @@ services:
       - db:/var/lib/mysql
     networks:
       - database
+  backup:
+    image: ${COMPOSE_PROJECT_NAME}_backup
+    build:
+      context: ..
+      dockerfile: docker/backup.Dockerfile
+    depends_on:
+      - database
+    environment:
+      MYSQL_HOST: database
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+    networks:
+      - database
+    volumes:
+      - backup:/backup
+    secrets:
+      - db_root_password
 volumes:
   db: {}
+  backup: {}
 
 networks:
   database:


### PR DESCRIPTION
This PR adds a simple backup service. It runs `mysqldump` daily and stores the dumps in a volume that the host can then backup as simple files. It retains all backups for a week, we might want to consider using `logrotate` instead.