### PR TITLE
Simplify rebase by using override file

### DIFF
--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,8 +4,8 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   1   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
-0   2   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
+0   *   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
+42  3   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -1,0 +1,13 @@
+FROM alpine
+
+RUN apk update && \
+    apk add mariadb-client && \
+    echo -e "\
+# m	h	d	m	wd	command\n\
+0   1   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
+0   2   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
+" > /root/crontab && \
+    crontab /root/crontab && \
+    mkdir /backup
+
+ENTRYPOINT /usr/sbin/crond -f -l 2

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -1,0 +1,77 @@
+---
+version: "3.6"
+services:
+  es_server:
+    environment:
+      MYSQL_HOST: es_database
+      MYSQL_USER: helferinnensystem
+      MYSQL_PASSWORD:
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+      MYSQL_DATABASE: helferinnensystem
+      APP_NAME: Helferinnensystem
+      CONTACT_EMAIL: "mailto:helfen@froscon.org"
+      THEME: 0
+      TSHIRT_SIZE_REQUIRED: 'false'
+      ANGEL_AUTOARRIVE: 'true'
+      SUPPORTERS_CAN_PROMOTE: 'true'
+      SIGNUP_POST_FRACTION: 1
+      PASSWORD_MINIMUM_LENGTH: 5
+      ENABLE_PLANNED_ARRIVAL: 'false'
+      ENABLE_FORCE_ACTIVE: 'false'
+      GOODIE_TYPE: none
+      ENABLE_VOUCHER: 'false'
+      NIGHT_SHIFTS: 'false'
+      IFSG_ENABLED: 'true'
+      IFSG_LIGHT_ENABLED: 'true'
+      DEFAULT_LOCALE: de_DE
+    secrets:
+      - db_password
+  es_database:
+    environment:
+      MYSQL_DATABASE: helferinnensystem
+      MYSQL_USER: helferinnensystem
+      MYSQL_PASSWORD:
+      MYSQL_PASSWORD_FILE: /run/secrets/db_password
+      MYSQL_RANDOM_ROOT_PASSWORD:
+      MYSQL_ROOT_PASSWORD:
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+      MYSQL_INITDB_SKIP_TZINFO: "yes"
+    secrets:
+      - db_root_password
+      - db_password
+  backup:
+    image: backup
+    build:
+      context: ..
+      dockerfile: docker/backup.Dockerfile
+    depends_on:
+      - es_database
+    environment:
+      MYSQL_HOST: es_database
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+    networks:
+      - database
+    volumes:
+      - backup:/backup
+    secrets:
+      - db_root_password
+  phpmyadmin:
+    image: phpmyadmin:latest
+    environment:
+      PMA_HOST: es_database
+    networks:
+      - database
+      - internet
+    ports:
+      - "5081:80"
+    profiles:
+      - dev
+
+volumes:
+  backup: {}
+
+secrets:
+  db_password:
+    file: secrets/mysql_pw.txt
+  db_root_password:
+    file: secrets/mysql_root_pw.txt

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -47,8 +47,25 @@ services:
       - db:/var/lib/mysql
     networks:
       - database
+  backup:
+    image: ${COMPOSE_PROJECT_NAME}_backup
+    build:
+      context: ..
+      dockerfile: docker/backup.Dockerfile
+    depends_on:
+      - database
+    environment:
+      MYSQL_HOST: database
+      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+    networks:
+      - database
+    volumes:
+      - backup:/backup
+    secrets:
+      - db_root_password
 volumes:
   db: {}
+  backup: {}
 
 networks:
   database:

--- a/docker/docker-compose.yml
+++ b/docker/docker-compose.yml
@@ -1,32 +1,16 @@
 ---
 version: "3.6"
 services:
-  server:
-    image: ${COMPOSE_PROJECT_NAME}_server
+  es_server:
+    image: es_server
     build:
       context: ..
       dockerfile: docker/Dockerfile
     environment:
-      MYSQL_HOST: database
-      MYSQL_USER: helferinnensystem
-      MYSQL_PASSWORD_FILE: /run/secrets/db_password
-      MYSQL_DATABASE: helferinnensystem
-      APP_NAME: Helferinnensystem
-      CONTACT_EMAIL: "mailto:helfen@froscon.org"
-      THEME: 0
-      TSHIRT_SIZE_REQUIRED: 'false'
-      ANGEL_AUTOARRIVE: 'true'
-      SUPPORTERS_CAN_PROMOTE: 'true'
-      SIGNUP_POST_FRACTION: 1
-      PASSWORD_MINIMUM_LENGTH: 5
-      ENABLE_PLANNED_ARRIVAL: 'false'
-      ENABLE_FORCE_ACTIVE: 'false'
-      GOODIE_TYPE: none
-      ENABLE_VOUCHER: 'false'
-      NIGHT_SHIFTS: 'false'
-      IFSG_ENABLED: 'true'
-      IFSG_LIGHT_ENABLED: 'true'
-      DEFAULT_LOCALE: de_DE
+      MYSQL_HOST: es_database
+      MYSQL_USER: engelsystem
+      MYSQL_PASSWORD: engelsystem
+      MYSQL_DATABASE: engelsystem
     ports:
       - "5080:80"
     env_file: deployment.env
@@ -34,62 +18,23 @@ services:
       - database
       - internet
     depends_on:
-      - database
-    secrets:
-      - db_password
-  database:
+      - es_database
+  es_database:
     image: mariadb:10.2
     environment:
-      MYSQL_DATABASE: helferinnensystem
-      MYSQL_USER: helferinnensystem
-      MYSQL_PASSWORD_FILE: /run/secrets/db_password
-      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
+      MYSQL_DATABASE: engelsystem
+      MYSQL_USER: engelsystem
+      MYSQL_PASSWORD: engelsystem
+      MYSQL_RANDOM_ROOT_PASSWORD: 1
       MYSQL_INITDB_SKIP_TZINFO: "yes"
     volumes:
       - db:/var/lib/mysql
     networks:
       - database
-    secrets:
-      - db_root_password
-      - db_password
-  backup:
-    image: ${COMPOSE_PROJECT_NAME}_backup
-    build:
-      context: ..
-      dockerfile: docker/backup.Dockerfile
-    depends_on:
-      - database
-    environment:
-      MYSQL_HOST: database
-      MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
-    networks:
-      - database
-    volumes:
-      - backup:/backup
-    secrets:
-      - db_root_password
-  phpmyadmin:
-    image: phpmyadmin:latest
-    environment:
-      PMA_HOST: database
-    networks:
-      - database
-      - internet
-    ports:
-      - "5081:80"
-    profiles:
-      - dev
 volumes:
   db: {}
-  backup: {}
 
 networks:
   database:
     internal: true
   internet:
-
-secrets:
-  db_password:
-    file: secrets/mysql_pw.txt
-  db_root_password:
-    file: secrets/mysql_root_pw.txt


### PR DESCRIPTION
We have a bunch of changes to the docker compose file, which makes rebasing painful. This moves everything to a docker compose override file. We can keep the original docker compose file and rebasing is easy.