### PR TITLE
Fix backup container

### DIFF
--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,7 +4,7 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
+0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction --ignore-table-data=${MYSQL_DATABASE}.sessions > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
 43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +3 -name '*.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,8 +4,8 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   *   *   *  *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
-43  3   *   *  *   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -delete\n\
+0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
+43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,8 +4,8 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   *   *   *	*   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d\`.sql\n\
-42  3   *   *	*   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -execdir rm -- '{}' \;\n\
+0   *   *   *  *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
+43  3   *   *  *   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -5,7 +5,7 @@ RUN apk update && \
     echo -e "\
 # m	h	d	m	wd	command\n\
 0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
-43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +7 -name '*.sql' -delete\n\
+43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +3 -name '*.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup

--- a/docker/docker-compose.override.yml
+++ b/docker/docker-compose.override.yml
@@ -55,6 +55,7 @@ services:
       - es_database
     environment:
       MYSQL_HOST: es_database
+      MYSQL_DATABASE: helferinnensystem
       MYSQL_ROOT_PASSWORD_FILE: /run/secrets/db_root_password
     networks:
       - database


### PR DESCRIPTION
The backup container contained commands in regular debian linux syntax that were incompatible with the alpine versions of find. Furthermore, we added a time to the backup file format and avoid exporting data from the `sessions` table which is over 70% for our case right now.