### PR TITLE
Fix backup

### DIFF
--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,7 +4,8 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction --ignore-table-data=\${MYSQL_DATABASE}.sessions > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
+0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --single-transaction --ignore-table-data=\${MYSQL_DATABASE}.sessions --ignore-table-data=\${MYSQL_DATABASE}.log_entries \${MYSQL_DATABASE} > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
+17  1   *   *   0   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`_weekly.sql\n\
 43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +3 -name '*.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \

--- a/docker/backup.Dockerfile
+++ b/docker/backup.Dockerfile
@@ -4,9 +4,10 @@ RUN apk update && \
     apk add mariadb-client && \
     echo -e "\
 # m	h	d	m	wd	command\n\
-0   *   *   *   *   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --single-transaction --ignore-table-data=\${MYSQL_DATABASE}.sessions --ignore-table-data=\${MYSQL_DATABASE}.log_entries \${MYSQL_DATABASE} > /backup/backup_\`date +%Y-%m-%d-%H-%M\`.sql\n\
-17  1   *   *   0   /usr/bin/mysqldump --host=\${MYSQL_HOST} --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`_weekly.sql\n\
-43  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +3 -name '*.sql' -delete\n\
+0   *   *   *   *   /usr/bin/mariadb-dump --host=\${MYSQL_HOST} --skip-ssl --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --single-transaction --ignore-table-data=\${MYSQL_DATABASE}.sessions --ignore-table-data=\${MYSQL_DATABASE}.log_entries \${MYSQL_DATABASE} > /backup/backup_\`date +%Y-%m-%d-%H-%M\`_daily.sql\n\
+17  1   *   *   0   /usr/bin/mariadb-dump --host=\${MYSQL_HOST} --skip-ssl --password=\`cat \${MYSQL_ROOT_PASSWORD_FILE}\` --all-databases --single-transaction > /backup/backup_\`date +%Y-%m-%d-%H-%M\`_weekly.sql\n\
+41  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +3 -name '*_daily.sql' -delete\n\
+42  3   *   *   *   /usr/bin/find /backup/ -type f -mtime +15 -name '*_weekly.sql' -delete\n\
 " > /root/crontab && \
     crontab /root/crontab && \
     mkdir /backup


### PR DESCRIPTION
The previous backup would backup all the databases every hour, excluding only the data of the `sessions` table of the main database. As it turns out, the `log_entries` contributes a lot of data as well, as do the databases of previous years. Unfortunately, it's not possible to ignore data based on a wildcard.
We decided to switch to a two-tiered backup: the current database is backed up hourly without `sessions` and `log_entries`, and all databases are backed up weekly. Data retention is adapted accordingly. We might still want to prune sessions from previous years eventually, but maybe that's not worth automating...