### PR TITLE
Reduce lifetime of anonymous sessions

### DIFF
--- a/config/app.php
+++ b/config/app.php
@@ -594,10 +594,17 @@ return [
                     'warning' => 'config.warning_logout',
                     'write_back' => true,
                 ],
+                'session.anonymous_lifetime' => [
+                    'type' => 'number',
+                    'required' => true,
+                    'default' => 30 * 60,
+                    'env' => 'SESSION_ANONYMOUS_LIFETIME',
+                    'write_back' => true,
+                ],
                 'session.lifetime' => [
                     'type' => 'number',
                     'required' => true,
-                    'default' => 30,
+                    'default' => 30 * 60 * 60 * 24,
                     'env' => 'SESSION_LIFETIME',
                     'write_back' => true,
                 ],

--- a/config/config.override.php
+++ b/config/config.override.php
@@ -1,0 +1,6 @@
+<?php
+
+return [
+    // Hide columns in backend user view. Possible values are any sortable parameters of the table.
+    'disabled_user_view_columns' => ['freeloads', 'active', 'arrival_date', 'departure_date'],
+];

--- a/config/config.override.php
+++ b/config/config.override.php
@@ -1,6 +1,0 @@
-<?php
-
-return [
-    // Hide columns in backend user view. Possible values are any sortable parameters of the table.
-    'disabled_user_view_columns' => ['freeloads', 'active', 'arrival_date', 'departure_date'],
-];

--- a/resources/lang/de_DE/additional.po
+++ b/resources/lang/de_DE/additional.po
@@ -738,8 +738,11 @@ msgstr "PHP Session"
 msgid "config.session.name"
 msgstr "Session Cookie Name"
 
+msgid "config.session.anonymous_lifetime"
+msgstr "Anonymous Session Laufzeit in Sekunden"
+
 msgid "config.session.lifetime"
-msgstr "Session Laufzeit in Tagen"
+msgstr "Session Laufzeit in Sekunden"
 
 msgid "config.jwt_expiration_time"
 msgstr "JWT Gültigkeit"

--- a/resources/lang/en_US/additional.po
+++ b/resources/lang/en_US/additional.po
@@ -731,8 +731,11 @@ msgstr "PHP session"
 msgid "config.session.name"
 msgstr "Session cookie name"
 
+msgid "config.session.anonymous_lifetime"
+msgstr "Anonymous session lifetime in seconds"
+
 msgid "config.session.lifetime"
-msgstr "Session lifetime in days"
+msgstr "Session lifetime in seconds"
 
 msgid "config.jwt_expiration_time"
 msgstr "JWT expiration time in minutes"

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends BaseController
         $this->session->invalidate();
         $this->session->set('user_id', $user->id);
         $this->session->set('locale', $user->settings->language);
-        $this->session->migrate(true, int($this->config->get('session')['lifetime']));
+        $this->session->migrate(true, (int)($this->config->get('session')['lifetime']));
 
         $user->last_login_at = new Carbon();
         $user->save(['touch' => false]);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -70,7 +70,7 @@ class AuthController extends BaseController
         $this->session->invalidate();
         $this->session->set('user_id', $user->id);
         $this->session->set('locale', $user->settings->language);
-        $this->session->migrate(true, $this->config->get('session')['lifetime']);
+        $this->session->migrate(true, int($this->config->get('session')['lifetime']));
 
         $user->last_login_at = new Carbon();
         $user->save(['touch' => false]);

--- a/src/Controllers/AuthController.php
+++ b/src/Controllers/AuthController.php
@@ -70,6 +70,7 @@ class AuthController extends BaseController
         $this->session->invalidate();
         $this->session->set('user_id', $user->id);
         $this->session->set('locale', $user->settings->language);
+        $this->session->migrate(true, $this->config->get('session')['lifetime']);
 
         $user->last_login_at = new Carbon();
         $user->save(['touch' => false]);

--- a/src/Http/SessionHandlers/DatabaseHandler.php
+++ b/src/Http/SessionHandlers/DatabaseHandler.php
@@ -60,20 +60,16 @@ class DatabaseHandler extends AbstractHandler
      */
     public function gc(int $max_lifetime): int|false
     {
-        $deleteBefore = Carbon::now()->subSeconds($config('session')['lifetime']);
-        $deleteAnonymousBefore = Carbon::now()->subSeconds($config('session')['anonymous_lifetime']);
+        $deleteBefore = Carbon::now()->subSeconds(config('session')['lifetime']);
+        $deleteAnonymousBefore = Carbon::now()->subSeconds(config('session')['anonymous_lifetime']);
 
         return
-            Session::where(function (Builder $query) {
-                $query
-                    ->where('user_id', '!=', 0)
-                    ->where('last_activity', '<', $deleteBefore);
-            })
-            ->orWhere(function (Builder $query) {
-                $query
-                    ->where('user_id', '=', 0)
-                    ->where('last_activity', '<', $deleteAnonymousBefore);
-            })
-            ->delete();
+            Session::where([
+                ["user_id", "!=", "0"],
+                ["last_activity", "<", $deleteBefore]
+            ])->orWhere([
+                ["user_id", "=", "0"],
+                ["last_activity", "<", $deleteAnonymousBefore]
+            ])->delete();
     }
 }

--- a/src/Http/SessionHandlers/DatabaseHandler.php
+++ b/src/Http/SessionHandlers/DatabaseHandler.php
@@ -60,10 +60,20 @@ class DatabaseHandler extends AbstractHandler
      */
     public function gc(int $max_lifetime): int|false
     {
-        $sessionDays = config('session')['lifetime'];
-        $deleteBefore = Carbon::now()->subDays($sessionDays);
+        $deleteBefore = Carbon::now()->subSeconds($config('session')['lifetime']);
+        $deleteAnonymousBefore = Carbon::now()->subSeconds($config('session')['anonymous_lifetime']);
 
-        return Session::where('last_activity', '<', $deleteBefore)
+        return
+            Session::where(function (Builder $query) {
+                $query
+                    ->where('user_id', '!=', 0)
+                    ->where('last_activity', '<', $deleteBefore);
+            })
+            ->orWhere(function (Builder $query) {
+                $query
+                    ->where('user_id', '=', 0)
+                    ->where('last_activity', '<', $deleteAnonymousBefore);
+            })
             ->delete();
     }
 }

--- a/src/Http/SessionServiceProvider.php
+++ b/src/Http/SessionServiceProvider.php
@@ -62,7 +62,7 @@ class SessionServiceProvider extends ServiceProvider
                 'name'            => $sessionConfig['name'],
                 'cookie_secure'   => $request->isSecure(),
                 'cookie_httponly' => true,
-                'cookie_lifetime' => (int) ($sessionConfig['lifetime'] * 24 * 60 * 60),
+                'cookie_lifetime' => (int) ($sessionConfig['anonymous_lifetime']),
             ],
             'handler' => $handler,
         ]);

--- a/tests/Unit/Http/SessionHandlers/DatabaseHandlerTest.php
+++ b/tests/Unit/Http/SessionHandlers/DatabaseHandlerTest.php
@@ -125,7 +125,7 @@ class DatabaseHandlerTest extends TestCase
      */
     public function testGc(): void
     {
-        $this->app->instance('config', new Config(['session' => ['lifetime' => 2]])); // 2 days
+        $this->app->instance('config', new Config(['session' => ['lifetime' => 2 * 24 * 60 * 60]])); // 2 days
 
         $table = $this->database->getConnection()->table('sessions');
         $table


### PR DESCRIPTION
This PR creates sessions with a small lifetime (30min) initially and then increases the lifetime on login. The main effect is that the sessions table is much smaller and thereby reduces the backup sizes by >90%.